### PR TITLE
Performance improvement

### DIFF
--- a/HtmlDiff/Action.cs
+++ b/HtmlDiff/Action.cs
@@ -1,0 +1,11 @@
+﻿namespace HtmlDiff
+{
+    public enum Action
+    {
+        Equal,
+        Delete,
+        Insert,
+        None,
+        Replace
+    }
+}

--- a/HtmlDiff/Diff.cs
+++ b/HtmlDiff/Diff.cs
@@ -427,6 +427,8 @@ namespace HtmlDiff
 
         private Match FindMatch(int startInOld, int endInOld, int startInNew, int endInNew)
         {
+            //For large texts it is more likely that there is a Match of size bigger than maximum granularity.
+            //If not then go down and try to find it with smaller granularity.
             for (int i = _matchGranularity; i > 0 ; i--)
             {
                 var finder = new MatchFinder(i, _oldWords, _newWords, startInOld, endInOld, startInNew, endInNew);

--- a/HtmlDiff/Diff.cs
+++ b/HtmlDiff/Diff.cs
@@ -70,10 +70,13 @@ namespace HtmlDiff
         private void SplitInputsToWords()
         {
             _oldWords = ConvertHtmlToListOfWords(Explode(_oldText));
-            //free memory
+
+            //free memory, allow it for GC
             _oldText = null;
+
             _newWords = ConvertHtmlToListOfWords(Explode(_newText));
-            //free memory
+
+            //free memory, allow it for GC
             _newText = null;
         }
 

--- a/HtmlDiff/HtmlDiff.csproj
+++ b/HtmlDiff/HtmlDiff.csproj
@@ -51,8 +51,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Action.cs" />
     <Compile Include="Diff.cs" />
+    <Compile Include="Match.cs" />
+    <Compile Include="MatchFinder.cs" />
+    <Compile Include="Mode.cs" />
+    <Compile Include="Operation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="HtmlDiff.nuspec">

--- a/HtmlDiff/Match.cs
+++ b/HtmlDiff/Match.cs
@@ -1,0 +1,26 @@
+namespace HtmlDiff
+{
+    public class Match
+    {
+        public Match(int startInOld, int startInNew, int size)
+        {
+            StartInOld = startInOld;
+            StartInNew = startInNew;
+            Size = size;
+        }
+
+        public int StartInOld { get; set; }
+        public int StartInNew { get; set; }
+        public int Size { get; set; }
+
+        public int EndInOld
+        {
+            get { return StartInOld + Size; }
+        }
+
+        public int EndInNew
+        {
+            get { return StartInNew + Size; }
+        }
+    }
+}

--- a/HtmlDiff/MatchFinder.cs
+++ b/HtmlDiff/MatchFinder.cs
@@ -3,6 +3,9 @@ using System.Text;
 
 namespace HtmlDiff
 {
+    /// <summary>
+    /// Finds biggest Match in given texts. It uses indexing with fixed granularity that is used to compare blocks of text.
+    /// </summary>
     public class MatchFinder
     {
         private readonly int _blockSize;
@@ -14,6 +17,15 @@ namespace HtmlDiff
         private readonly int _endInNew;
         private Dictionary<string, List<int>> _wordIndices;
 
+        /// <summary>
+        /// </summary>
+        /// <param name="blockSize">Match granularity, defines how many words are joined into single block</param>
+        /// <param name="oldWords"></param>
+        /// <param name="newWords"></param>
+        /// <param name="startInOld"></param>
+        /// <param name="endInOld"></param>
+        /// <param name="startInNew"></param>
+        /// <param name="endInNew"></param>
         public MatchFinder(int blockSize, string[] oldWords, string[] newWords, int startInOld, int endInOld, int startInNew, int endInNew)
         {
             _blockSize = blockSize;

--- a/HtmlDiff/MatchFinder.cs
+++ b/HtmlDiff/MatchFinder.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace HtmlDiff
+{
+    public class MatchFinder
+    {
+        private readonly int _blockSize;
+        private readonly string[] _oldWords;
+        private readonly string[] _newWords;
+        private readonly int _startInOld;
+        private readonly int _endInOld;
+        private readonly int _startInNew;
+        private readonly int _endInNew;
+        private Dictionary<string, List<int>> _wordIndices;
+
+        public MatchFinder(int blockSize, string[] oldWords, string[] newWords, int startInOld, int endInOld, int startInNew, int endInNew)
+        {
+            _blockSize = blockSize;
+            _oldWords = oldWords;
+            _newWords = newWords;
+            _startInOld = startInOld;
+            _endInOld = endInOld;
+            _startInNew = startInNew;
+            _endInNew = endInNew;
+        }
+
+        private void IndexNewWords()
+        {
+            _wordIndices = new Dictionary<string, List<int>>();
+            var block = new Queue<string>(_blockSize);
+            for (int i = _startInNew; i < _endInNew; i++)
+            {
+                var word = ToCleanWord(_newWords[i]);
+                var key = PutNewWord(block, word, _blockSize);
+
+                if (key == null)
+                    continue;
+
+                if (_wordIndices.ContainsKey(key))
+                {
+                    _wordIndices[key].Add(i);
+                }
+                else
+                {
+                    _wordIndices[key] = new List<int> { i };
+                }
+            }
+        }
+
+        private static string PutNewWord(Queue<string> block, string word, int blockSize)
+        {
+            block.Enqueue(word);
+            if (block.Count > blockSize)
+                block.Dequeue();
+
+            if (block.Count != blockSize)
+                return null;
+            
+            var result = new StringBuilder();
+            foreach (var s in block)
+            {
+                result.Append(s);
+            }
+            return result.ToString();
+        }
+
+        private static string ToCleanWord(string word)
+        {
+            // if word is a tag, we should ignore attributes as attribute changes are not supported (yet)
+            if (Utils.IsTag(word))
+            {
+                word = Utils.StripTagAttributes(word);
+            }
+            return word;
+        }
+
+        public Match FindMatch()
+        {
+            IndexNewWords();
+
+            if (_wordIndices.Count == 0)
+                return null;
+
+            int bestMatchInOld = _startInOld;
+            int bestMatchInNew = _startInNew;
+            int bestMatchSize = 0;
+
+            var matchLengthAt = new Dictionary<int, int>();
+            var block = new Queue<string>(_blockSize);
+
+            for (int indexInOld = _startInOld; indexInOld < _endInOld; indexInOld++)
+            {
+                var word = ToCleanWord(_oldWords[indexInOld]);
+                var index = PutNewWord(block, word, _blockSize);
+                if (index == null)
+                    continue;
+
+                var newMatchLengthAt = new Dictionary<int, int>();
+
+                if (!_wordIndices.ContainsKey(index))
+                {
+                    matchLengthAt = newMatchLengthAt;
+                    continue;
+                }
+
+                foreach (int indexInNew in _wordIndices[index])
+                {
+                    int newMatchLength = (matchLengthAt.ContainsKey(indexInNew - 1) ? matchLengthAt[indexInNew - 1] : 0) +
+                                         1;
+                    newMatchLengthAt[indexInNew] = newMatchLength;
+
+                    if (newMatchLength > bestMatchSize)
+                    {
+                        bestMatchInOld = indexInOld - newMatchLength + 1 - _blockSize + 1;
+                        bestMatchInNew = indexInNew - newMatchLength + 1 - _blockSize + 1;
+                        bestMatchSize = newMatchLength;
+                    }
+                }
+
+                matchLengthAt = newMatchLengthAt;
+            }
+
+            return bestMatchSize != 0 ? new Match(bestMatchInOld, bestMatchInNew, bestMatchSize + _blockSize - 1) : null;
+        }
+    }
+}

--- a/HtmlDiff/Mode.cs
+++ b/HtmlDiff/Mode.cs
@@ -1,0 +1,9 @@
+﻿namespace HtmlDiff
+{
+    public enum Mode
+    {
+        Character,
+        Tag,
+        Whitespace,
+    }
+}

--- a/HtmlDiff/Operation.cs
+++ b/HtmlDiff/Operation.cs
@@ -1,0 +1,20 @@
+namespace HtmlDiff
+{
+    public class Operation
+    {
+        public Operation(Action action, int startInOld, int endInOld, int startInNew, int endInNew)
+        {
+            Action = action;
+            StartInOld = startInOld;
+            EndInOld = endInOld;
+            StartInNew = startInNew;
+            EndInNew = endInNew;
+        }
+
+        public Action Action { get; set; }
+        public int StartInOld { get; set; }
+        public int EndInOld { get; set; }
+        public int StartInNew { get; set; }
+        public int EndInNew { get; set; }
+    }
+}

--- a/HtmlDiff/Utils.cs
+++ b/HtmlDiff/Utils.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace HtmlDiff
+{
+    public static class Utils
+    {
+        private static readonly string[] SpecialCaseWordTags = { "<img" };
+
+        public static bool IsTag(string item)
+        {
+            if (SpecialCaseWordTags.Any(re => item != null && item.StartsWith(re))) return false;
+            return IsOpeningTag(item) || IsClosingTag(item);
+        }
+
+        private static bool IsOpeningTag(string item)
+        {
+            return Regex.IsMatch(item, "^\\s*<[^>]+>\\s*$");
+        }
+
+        private static bool IsClosingTag(string item)
+        {
+            return Regex.IsMatch(item, "^\\s*</[^>]+>\\s*$");
+        }
+
+        public static string StripTagAttributes(string word)
+        {
+            string tag = Regex.Match(word, @"<[^\s>]+", RegexOptions.None).Value;
+            word = tag + (word.EndsWith("/>") ? "/>" : ">");
+            return word;
+        }
+    }
+}

--- a/Test.HtmlDiff/HtmlDiffSpecTests.cs
+++ b/Test.HtmlDiff/HtmlDiffSpecTests.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
 
 namespace Test.HtmlDiff
 {
@@ -19,6 +22,47 @@ namespace Test.HtmlDiff
         public void Execute_WithStandardSpecs_OutputVerified(string oldtext, string newText, string delta)
         {
             Assert.AreEqual(delta, global::HtmlDiff.HtmlDiff.Execute(oldtext, newText));
+        }
+
+        [Test(Description = "This is a benchmark test, it requires much memory and cpu to run so by default is disabled")]
+        public void ExecutePerformance_WithLongText()
+        {
+            Assert.Inconclusive("Disabled by default");
+
+            const int iterations = 300;
+            const string template = @"Lorem ipsum dolor sit amet {0}, consectetur adipiscing elit. Nunc sollicitudin mauris eget nibh {1} semper, in bibendum felis rutrum. Aliquam dictum {2} ut ante id dictum. Integer quis tincidunt metus. Maecenas ultricies tristique {3} fringilla. Cras non erat id elit rhoncus accumsan eget quis neque. Fusce accumsan justo mauris, et pulvinar leo lacinia molestie. Nam ullamcorper dapibus velit a pulvinar. Cras a hendrerit neque {4}, sit amet faucibus ante. {5} Nullam in nisl augue. Suspendisse consectetur id ipsum at dignissim. Etiam euismod sollicitudin metus non volutpat,{6}. Nullam non mollis risus, nec consequat ipsum.";
+            var words = "Donec condimentum, tellus a aliquam feugiat, dui diam fringilla massa, sed facilisis risus magna quis augue. Aenean tempus metus at quam aliquet, ultrices venenatis nulla faucibus. Maecenas sit amet lobortis tortor. Vestibulum fringilla fringilla diam, non tempus quam pretium gravida. In pretium vitae erat sed bibendum. Sed ultrices risus et aliquet sollicitudin. Fusce ac diam justo. Morbi lobortis quam vestibulum volutpat cursus. Suspendisse vestibulum augue et interdum convallis.".
+                        Split(' ').Cast<object>().ToArray();
+            var empty = Enumerable.Repeat((object)"", words.Length).ToArray();
+
+            var oldText = new StringBuilder();
+            for (int i = 0; i < iterations; i++)
+            {
+                if (i % 2 == 0)
+                    oldText.AppendFormat(template, empty);
+                else if (i % 5 == 0)
+                    oldText.AppendFormat(template, words.Skip(i % words.Length).Concat(words.Skip(words.Length - (i % words.Length))).ToArray());
+                else if (i % 7 == 0)
+                    oldText.AppendFormat(template, words);
+            }
+
+            words = words.Reverse().ToArray();
+            var newText = new StringBuilder();
+            for (int i = 0; i < iterations; i++)
+            {
+                if (i % 3 == 0)
+                    newText.AppendFormat(template, empty);
+                else if (i % 2 == 0)
+                    newText.AppendFormat(template, words.Skip(i % words.Length).Concat(words.Skip(words.Length - (i % words.Length))).ToArray());
+                else if (i % 11 == 0)
+                    newText.AppendFormat(template, words);
+            }
+
+            var s = Stopwatch.StartNew();
+            var delta = global::HtmlDiff.HtmlDiff.Execute(oldText.ToString(), newText.ToString());
+            s.Stop();
+            Assert.IsNotNullOrEmpty(delta);
+            Debug.WriteLine("Execution time: {0}, oldText size: {1}, newText size: {2}, delta size: {3}", s.Elapsed, oldText.Length, newText.Length, delta.Length);
         }
     }
 }


### PR DESCRIPTION
In general this pull request contains improved version of method HtmlDiff.FindMatch() that now executes much faster, especially with large texts. With some test it takes only 6 seconds vs 3.5 min. There is also small refactoring: some types are moved to separate files to lighten Diff.cs file.