### PR TITLE
Html entities, whitespaces, performance

### DIFF
--- a/HtmlDiff/Diff.cs
+++ b/HtmlDiff/Diff.cs
@@ -63,12 +63,15 @@ namespace HtmlDiff
         /// 11111 bb 222222222 dddddd ee
         /// </code>
         /// will find two matches <code>bb</code> and <code>dddddd ee</code> but the first will be considered
-        /// as orphan and ignored:
+        /// as orphan and ignored, as result it will consider texts <code>aaaaa bb ccccccccc</code> and
+        /// <code>11111 bb 222222222</code> as single replacement:
         /// <code>
         /// &lt;del&gt;aaaaa bb ccccccccc&lt;/del&gt;&lt;ins&gt;11111 bb 222222222&lt;/ins&gt; dddddd ee
         /// </code>
         /// This property defines relative size of the match to be considered as orphan, from 0 to 1.
-        /// 0.2 is default.
+        /// 1 means that all matches will be considered as orphans.
+        /// 0 (default) means that no match will be considered as orphan.
+        /// 0.2 means that if match length is less than 20% of distance between its neighbors it is considered as orphan.
         /// </summary>
         public double OrphanMatchThreshold { get; set; }
 
@@ -80,7 +83,6 @@ namespace HtmlDiff
         public HtmlDiff(string oldText, string newText)
         {
             RepeatingWordsAccuracy = 1d; //by default all repeating words should be compared
-            OrphanMatchThreshold = 0.2d;
 
             _oldText = oldText;
             _newText = newText;

--- a/HtmlDiff/HtmlDiff.csproj
+++ b/HtmlDiff/HtmlDiff.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Diff.cs" />
     <Compile Include="Match.cs" />
     <Compile Include="MatchFinder.cs" />
+    <Compile Include="MatchOptions.cs" />
     <Compile Include="Mode.cs" />
     <Compile Include="Operation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/HtmlDiff/MatchFinder.cs
+++ b/HtmlDiff/MatchFinder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace HtmlDiff
@@ -6,9 +7,8 @@ namespace HtmlDiff
     /// <summary>
     /// Finds biggest Match in given texts. It uses indexing with fixed granularity that is used to compare blocks of text.
     /// </summary>
-    public class MatchFinder
+    internal class MatchFinder
     {
-        private readonly int _blockSize;
         private readonly string[] _oldWords;
         private readonly string[] _newWords;
         private readonly int _startInOld;
@@ -16,35 +16,36 @@ namespace HtmlDiff
         private readonly int _startInNew;
         private readonly int _endInNew;
         private Dictionary<string, List<int>> _wordIndices;
+        private readonly MatchOptions _options;
 
         /// <summary>
         /// </summary>
-        /// <param name="blockSize">Match granularity, defines how many words are joined into single block</param>
         /// <param name="oldWords"></param>
         /// <param name="newWords"></param>
         /// <param name="startInOld"></param>
         /// <param name="endInOld"></param>
         /// <param name="startInNew"></param>
         /// <param name="endInNew"></param>
-        public MatchFinder(int blockSize, string[] oldWords, string[] newWords, int startInOld, int endInOld, int startInNew, int endInNew)
+        /// <param name="options"></param>
+        public MatchFinder(string[] oldWords, string[] newWords, int startInOld, int endInOld, int startInNew, int endInNew, MatchOptions options)
         {
-            _blockSize = blockSize;
             _oldWords = oldWords;
             _newWords = newWords;
             _startInOld = startInOld;
             _endInOld = endInOld;
             _startInNew = startInNew;
             _endInNew = endInNew;
+            _options = options;
         }
 
         private void IndexNewWords()
         {
             _wordIndices = new Dictionary<string, List<int>>();
-            var block = new Queue<string>(_blockSize);
+            var block = new Queue<string>(_options.BlockSize);
             for (int i = _startInNew; i < _endInNew; i++)
             {
                 var word = ToCleanWord(_newWords[i]);
-                var key = PutNewWord(block, word, _blockSize);
+                var key = PutNewWord(block, word, _options.BlockSize);
 
                 if (key == null)
                     continue;
@@ -77,19 +78,23 @@ namespace HtmlDiff
             return result.ToString();
         }
 
-        private static string ToCleanWord(string word)
+        private string ToCleanWord(string word)
         {
             // if word is a tag, we should ignore attributes as attribute changes are not supported (yet)
             if (Utils.IsTag(word))
             {
                 word = Utils.StripTagAttributes(word);
             }
+            if (_options.IgnoreWhitespaceDifferences && Utils.IsWhitespace(word))
+                return " ";
+
             return word;
         }
 
         public Match FindMatch()
         {
             IndexNewWords();
+            RemoveRepeatingWords();
 
             if (_wordIndices.Count == 0)
                 return null;
@@ -99,12 +104,12 @@ namespace HtmlDiff
             int bestMatchSize = 0;
 
             var matchLengthAt = new Dictionary<int, int>();
-            var block = new Queue<string>(_blockSize);
+            var block = new Queue<string>(_options.BlockSize);
 
             for (int indexInOld = _startInOld; indexInOld < _endInOld; indexInOld++)
             {
                 var word = ToCleanWord(_oldWords[indexInOld]);
-                var index = PutNewWord(block, word, _blockSize);
+                var index = PutNewWord(block, word, _options.BlockSize);
                 if (index == null)
                     continue;
 
@@ -124,8 +129,8 @@ namespace HtmlDiff
 
                     if (newMatchLength > bestMatchSize)
                     {
-                        bestMatchInOld = indexInOld - newMatchLength + 1 - _blockSize + 1;
-                        bestMatchInNew = indexInNew - newMatchLength + 1 - _blockSize + 1;
+                        bestMatchInOld = indexInOld - newMatchLength + 1 - _options.BlockSize + 1;
+                        bestMatchInNew = indexInNew - newMatchLength + 1 - _options.BlockSize + 1;
                         bestMatchSize = newMatchLength;
                     }
                 }
@@ -133,7 +138,22 @@ namespace HtmlDiff
                 matchLengthAt = newMatchLengthAt;
             }
 
-            return bestMatchSize != 0 ? new Match(bestMatchInOld, bestMatchInNew, bestMatchSize + _blockSize - 1) : null;
+            return bestMatchSize != 0 ? new Match(bestMatchInOld, bestMatchInNew, bestMatchSize + _options.BlockSize - 1) : null;
+        }
+
+        /// <summary>
+        /// This method removes words that occur too many times. This way it reduces total count of comparison operations
+        /// and as result the diff algoritm takes less time. But the side effect is that it may detect false differences of
+        /// the repeating words.
+        /// </summary>
+        private void RemoveRepeatingWords()
+        {
+            var threshold = _newWords.Length * _options.RepeatingWordsAccuracy;
+            var repeatingWords = _wordIndices.Where(i => i.Value.Count > threshold).Select(i => i.Key).ToArray();
+            foreach (var w in repeatingWords)
+            {
+                _wordIndices.Remove(w);
+            }
         }
     }
 }

--- a/HtmlDiff/MatchOptions.cs
+++ b/HtmlDiff/MatchOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace HtmlDiff
+{
+    internal struct MatchOptions
+    {
+        /// <summary>
+        /// Match granularity, defines how many words are joined into single block
+        /// </summary>
+        public int BlockSize { get; set; }
+
+        public double RepeatingWordsAccuracy { get; set; }
+
+        public bool IgnoreWhitespaceDifferences { get; set; }
+
+    }
+}

--- a/HtmlDiff/Mode.cs
+++ b/HtmlDiff/Mode.cs
@@ -5,5 +5,6 @@
         Character,
         Tag,
         Whitespace,
+        Entity,
     }
 }

--- a/HtmlDiff/Utils.cs
+++ b/HtmlDiff/Utils.cs
@@ -29,5 +29,10 @@ namespace HtmlDiff
             word = tag + (word.EndsWith("/>") ? "/>" : ">");
             return word;
         }
+
+        public static bool IsWhitespace(string item)
+        {
+            return Regex.IsMatch(item, "^(\\s|&nbsp;)+$");
+        }
     }
 }

--- a/Test.HtmlDiff/Bugs/DiffTests.cs
+++ b/Test.HtmlDiff/Bugs/DiffTests.cs
@@ -16,7 +16,7 @@ namespace Test.HtmlDiff.Bugs
             var oldText = "The Dealer.";
             var newText = "The Dealer info,";
             var output = global::HtmlDiff.HtmlDiff.Execute(oldText, newText);
-            Assert.AreEqual("The Dealer<del class='diffmod'>.</del><ins class='diffmod'> info,</ins>", output);
+            Assert.AreEqual("The Dealer<del class='diffmod'>.</del><ins class='diffmod'>&nbsp;info,</ins>", output);
         }
     }
 }

--- a/Test.HtmlDiff/HtmlDiffSpecTests.cs
+++ b/Test.HtmlDiff/HtmlDiffSpecTests.cs
@@ -9,7 +9,7 @@ namespace Test.HtmlDiff
     public class HtmlDiffSpecTests
     {
         // Shamelessly copied specs from here with a few modifications: https://github.com/myobie/htmldiff/blob/master/spec/htmldiff_spec.rb
-        [TestCase("a word is here", "a nother word is there", "a<ins class='diffins'> nother</ins> word is <del class='diffmod'>here</del><ins class='diffmod'>there</ins>")]
+        [TestCase("a word is here", "a nother word is there", "a<ins class='diffins'>&nbsp;nother</ins> word is <del class='diffmod'>here</del><ins class='diffmod'>there</ins>")]
         [TestCase("a c", "a b c", "a <ins class='diffins'>b </ins>c")]
         [TestCase("a b c", "a c", "a <del class='diffdel'>b </del>c")]
         [TestCase("a b c", "a <strong>b</strong> c", "a <strong><ins class='mod'>b</ins></strong> c")]
@@ -18,7 +18,7 @@ namespace Test.HtmlDiff
         [TestCase("<img src='logo.jpg'/>", "", "<del class='diffdel'><img src='logo.jpg'/></del>")]
         [TestCase("", "<img src='logo.jpg'/>", "<ins class='diffins'><img src='logo.jpg'/></ins>")]
         [TestCase("symbols 'should not' belong <b>to</b> words", "symbols should not belong <b>\"to\"</b> words", "symbols <del class='diffdel'>'</del>should not<del class='diffdel'>'</del> belong <b><ins class='diffins'>\"</ins>to<ins class='diffins'>\"</ins></b> words")]
-        [TestCase("entities are separate amp;words", "entities are&nbsp;separate &amp;words", "entities are<del class='diffmod'> </del><ins class='diffmod'>&nbsp;</ins>separate <del class='diffmod'>amp;</del><ins class='diffmod'>&amp;</ins>words")]
+        [TestCase("entities are separate amp;words", "entities are&nbsp;separate &amp;words", "entities are<del class='diffmod'>&nbsp;</del><ins class='diffmod'>&nbsp;</ins>separate <del class='diffmod'>amp;</del><ins class='diffmod'>&amp;</ins>words")]
 
         [TestCase(
             "This is a longer piece of text to ensure the new blocksize algorithm works", 
@@ -47,7 +47,7 @@ namespace Test.HtmlDiff
         [TestCase("one a word is somewhere", "two a nother word is somewhere",
                   "<del class='diffmod'>one a</del><ins class='diffmod'>two a nother</ins> word is somewhere", 0.2d)]
         [TestCase("one a word is somewhere", "two a nother word is somewhere",
-                  "<del class='diffmod'>one</del><ins class='diffmod'>two</ins> a<ins class='diffins'> nother</ins> word is somewhere", 0.1d)]
+                  "<del class='diffmod'>one</del><ins class='diffmod'>two</ins> a<ins class='diffins'>&nbsp;nother</ins> word is somewhere", 0.1d)]
         public void Execute_WithOrphanMatchThreshold_OutputVerified(string oldtext, string newText, string delta, double orphanMatchThreshold)
         {
             Debug.WriteLine("Old text: " + oldtext);

--- a/Test.HtmlDiff/HtmlDiffSpecTests.cs
+++ b/Test.HtmlDiff/HtmlDiffSpecTests.cs
@@ -10,7 +10,6 @@ namespace Test.HtmlDiff
     {
         // Shamelessly copied specs from here with a few modifications: https://github.com/myobie/htmldiff/blob/master/spec/htmldiff_spec.rb
         [TestCase("a word is here", "a nother word is there", "a<ins class='diffins'> nother</ins> word is <del class='diffmod'>here</del><ins class='diffmod'>there</ins>")]
-        [TestCase("one a word is somewhere", "two a nother word is somewhere", "<del class='diffmod'>one a</del><ins class='diffmod'>two a nother</ins> word is somewhere")]
         [TestCase("a c", "a b c", "a <ins class='diffins'>b </ins>c")]
         [TestCase("a b c", "a c", "a <del class='diffdel'>b </del>c")]
         [TestCase("a b c", "a <strong>b</strong> c", "a <strong><ins class='mod'>b</ins></strong> c")]
@@ -40,6 +39,22 @@ namespace Test.HtmlDiff
             Debug.WriteLine("");
             Debug.WriteLine("Expected Diff: " + delta);
             var result = global::HtmlDiff.HtmlDiff.Execute(oldtext, newText);
+            Debug.WriteLine("");
+            Debug.WriteLine("Actual Diff: " + result);
+            Assert.AreEqual(delta, result);
+        }
+
+        [TestCase("one a word is somewhere", "two a nother word is somewhere",
+                  "<del class='diffmod'>one a</del><ins class='diffmod'>two a nother</ins> word is somewhere", 0.2d)]
+        [TestCase("one a word is somewhere", "two a nother word is somewhere",
+                  "<del class='diffmod'>one</del><ins class='diffmod'>two</ins> a<ins class='diffins'> nother</ins> word is somewhere", 0.1d)]
+        public void Execute_WithOrphanMatchThreshold_OutputVerified(string oldtext, string newText, string delta, double orphanMatchThreshold)
+        {
+            Debug.WriteLine("Old text: " + oldtext);
+            Debug.WriteLine("New text: " + newText);
+            Debug.WriteLine("");
+            Debug.WriteLine("Expected Diff: " + delta);
+            var result = new global::HtmlDiff.HtmlDiff(oldtext, newText) { OrphanMatchThreshold = orphanMatchThreshold }.Build();
             Debug.WriteLine("");
             Debug.WriteLine("Actual Diff: " + result);
             Assert.AreEqual(delta, result);

--- a/Test.HtmlDiff/HtmlDiffSpecTests.cs
+++ b/Test.HtmlDiff/HtmlDiffSpecTests.cs
@@ -10,15 +10,18 @@ namespace Test.HtmlDiff
     {
         // Shamelessly copied specs from here with a few modifications: https://github.com/myobie/htmldiff/blob/master/spec/htmldiff_spec.rb
         [TestCase("a word is here", "a nother word is there", "a<ins class='diffins'> nother</ins> word is <del class='diffmod'>here</del><ins class='diffmod'>there</ins>")]
+        [TestCase("one a word is somewhere", "two a nother word is somewhere", "<del class='diffmod'>one a</del><ins class='diffmod'>two a nother</ins> word is somewhere")]
         [TestCase("a c", "a b c", "a <ins class='diffins'>b </ins>c")]
         [TestCase("a b c", "a c", "a <del class='diffdel'>b </del>c")]
         [TestCase("a b c", "a d c", "a <del class='diffmod'>b</del><ins class='diffmod'>d</ins> c")]
         [TestCase("<a title='xx'>test</a>", "<a title='yy'>test</a>", "<a title='yy'>test</a>")]
         [TestCase("<img src='logo.jpg'/>", "", "<del class='diffdel'><img src='logo.jpg'/></del>")]
         [TestCase("", "<img src='logo.jpg'/>", "<ins class='diffins'><img src='logo.jpg'/></ins>")]
+        [TestCase("symbols 'should not' belong <b>to</b> words", "symbols should not belong <b>\"to\"</b> words", "symbols <del class='diffdel'>'</del>should not<del class='diffdel'>'</del> belong <b><ins class='diffins'>\"</ins>to<ins class='diffins'>\"</ins></b> words")]
+        [TestCase("entities are separate amp;words", "entities are&nbsp;separate &amp;words", "entities are<del class='diffmod'> </del><ins class='diffmod'>&nbsp;</ins>separate <del class='diffmod'>amp;</del><ins class='diffmod'>&amp;</ins>words")]
 
         // TODO: Don't speak Chinese, this needs to be validated
-        [TestCase("这个是中文内容, CSharp is the bast", "这是中国语内容，CSharp is the best language.", "这<del class='diffdel'>个</del>是中<del class='diffmod'>文</del><ins class='diffmod'>国语</ins>内容<del class='diffmod'>, CSharp</del><ins class='diffmod'>，CSharp</ins> is the <del class='diffmod'>bast</del><ins class='diffmod'>best language.</ins>")]
+        [TestCase("这个是中文内容, CSharp is the bast", "这是中国语内容，CSharp is the best language.", "这<del class='diffdel'>个</del>是中<del class='diffmod'>文</del><ins class='diffmod'>国语</ins>内容<del class='diffmod'>, </del><ins class='diffmod'>，</ins>CSharp is the <del class='diffmod'>bast</del><ins class='diffmod'>best language.</ins>")]
         public void Execute_WithStandardSpecs_OutputVerified(string oldtext, string newText, string delta)
         {
             Assert.AreEqual(delta, global::HtmlDiff.HtmlDiff.Execute(oldtext, newText));


### PR DESCRIPTION
* Correct handling of html entities like &amp;quot;, &amp;nbsp;, &amp;amp; ...
* Option to ignore whitespace differences
* Method ConvertHtmlToListOfWords highly optimized. Split string into characters instead of strings, this prevents CLR of allocating memory for each string, as result it takes less time and memory
*  Improvement: better representation of differences, I call it Orphan Matches, often they impair readability and the diff looks much better if they are omitted
* Option to increase performance of ugly html files that are created by some rich text editors like MS Word (I call it RepeatingWords)

In general these improvements are useful when comparing large pages like technical or financial articles.