### PR TITLE
Enabled to generate documenation file to be included in the NuGet package

### DIFF
--- a/HtmlDiff/HtmlDiff.csproj
+++ b/HtmlDiff/HtmlDiff.csproj
@@ -17,6 +17,11 @@
     <PackageLicenseFile>license.txt</PackageLicenseFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\license.txt">
       <Pack>True</Pack>


### PR DESCRIPTION
The published NuGet packages do not contain any xmldocs documentation, while they are defined in code.
This change adds them in Release mode so they will be available in the next release.