### PR TITLE
ConvertHtmlToListOfWords issue. Splitting text into words fitting a block definition

### DIFF
--- a/src/HtmlDiff.Tests/HtmlDiff.Tests.csproj
+++ b/src/HtmlDiff.Tests/HtmlDiff.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Nunit" Version="3.13.2" />

--- a/src/HtmlDiff.Tests/WordSplitterSpecTests.cs
+++ b/src/HtmlDiff.Tests/WordSplitterSpecTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.RegularExpressions;
+using NUnit.Framework;
+using NExpect;
+using static NExpect.Expectations;
+
+namespace HtmlDiff.Tests
+{
+    [TestFixture]
+    public class WordSplitterSpecTests
+    {
+        [Test]
+        [TestCase("<td>(.*?)</td>", "<td>n a</td><td>c</td>", new[] { "<td>n a</td>", "<td>c</td>" })]
+        [TestCase("<td>(.*?)</td>", "<td>n a</td><br/><td>c</td>", new[] { "<td>n a</td>", "<br/>", "<td>c</td>" })]
+        public void ConvertHtmlToListOfWords_WithGroups_WordsSplitEndOfGroup(string regex, string text, string[] expected)
+        {
+            // Arrange
+
+            // Act
+            var words = WordSplitter.ConvertHtmlToListOfWords(
+                text,
+                new[] { new Regex(regex, RegexOptions.IgnoreCase) });
+
+            // Assert
+            Expect(words)
+                .To.Equal(expected);
+        }
+    }
+}

--- a/src/HtmlDiff/WordSplitter.cs
+++ b/src/HtmlDiff/WordSplitter.cs
@@ -35,6 +35,15 @@ namespace HtmlDiff
                     {
                         groupingUntil = -1;
                         isGrouping = false;
+
+                        // We reached the end of the group, add the current word to the list
+                        // and start new search
+                        if (currentWord.Count != 0)
+                        {
+                            words.Add(new string(currentWord.ToArray()));
+                        }
+
+                        currentWord.Clear();
                     }
 
                     // Check if we need to group the next text sequence/block


### PR DESCRIPTION
There is an issue with the WordSplitter.ConvertHtmlToListOfWords(). The text doesn't split into words corresponding to the group definition.
For example, if you use a group like this: "`<td>(.*?)</td>`" the following text  "`<td>a</td><td>c</td>`" should split into two words: "`<td>a</td>`", "`<td>c</td>`" 