### PR TITLE
Bugfix/issue20 missing closing tag

### DIFF
--- a/src/HtmlDiff.Tests/Bugs/Issue20.cs
+++ b/src/HtmlDiff.Tests/Bugs/Issue20.cs
@@ -1,0 +1,48 @@
+﻿using NExpect;
+using NUnit.Framework;
+using static NExpect.Expectations;
+
+namespace HtmlDiff.Tests.Bugs
+{
+    [TestFixture]
+    public class Issue20
+    {
+        // https://github.com/Rohland/htmldiff.net/issues/20
+
+        // Original Testcase from Issue 20, but with the correct expected result (the original expected result was missing the <ins class='mod'>[...]</ins>)
+        [TestCase("<div class=\"dumb\">Thiis a text without any sup-tags and other special things</div>",
+             "<div class=\"dumb\">Thiis a text <sup>1</sup>without any sup-tags and other special things</div>",
+             "<div class=\"dumb\">Thiis a text <sup><ins class='mod'><ins class='diffins'>1</ins></ins></sup>without any sup-tags and other special things</div>")]
+
+        // Inserting a new word at the end of the reformatted text
+        [TestCase("<span>text bleibt</span>",
+              "<span><strong>text bleibt Test</strong></span>",
+              "<span><strong><ins class='mod'>text bleibt<ins class='diffins'>&nbsp;Test</ins></ins></strong></span>")]
+
+        // Inserting a new word at the end of a reformatted text and another word at the end outside the reformatted text
+        [TestCase("<span>text bleibt</span>",
+             "<span><strong>text bleibt Test</strong> Test</span>",
+             "<span><strong><ins class='mod'>text bleibt<ins class='diffins'>&nbsp;Test</ins></ins></strong><ins class='diffins'>&nbsp;Test</ins></span>")]
+
+        // Twice reformatted text with an offset at the end
+        [TestCase("<span>text bleibt</span>",
+             "<span><strong><big>text </big>bleibt</strong></span>",
+             "<span><strong><big><ins class='mod'>text </big>bleibt</ins></strong></span>")]
+
+        // Inserting a new word at the beginning of a reformatted text.
+        [TestCase("<span>text bleibt</span>",
+             "<span><strong>Test text bleibt</strong></span>",
+             "<span><strong><ins class='mod'><ins class='diffins'>Test </ins>text bleibt</ins></strong></span>")]
+        public void TestCase_Issue20_missing_closing_tag(string oldText, string newText, string expectedResult)
+        {
+            // Arrange
+            var diff = new HtmlDiff(oldText, newText);
+
+            string result = diff.Build();
+
+            // Assert
+            Expect(result)
+                 .To.Equal(expectedResult);
+        }
+    }
+}

--- a/src/HtmlDiff.Tests/Bugs/Issue20.cs
+++ b/src/HtmlDiff.Tests/Bugs/Issue20.cs
@@ -15,24 +15,24 @@ namespace HtmlDiff.Tests.Bugs
              "<div class=\"dumb\">Thiis a text <sup><ins class='mod'><ins class='diffins'>1</ins></ins></sup>without any sup-tags and other special things</div>")]
 
         // Inserting a new word at the end of the reformatted text
-        [TestCase("<span>text bleibt</span>",
-              "<span><strong>text bleibt Test</strong></span>",
-              "<span><strong><ins class='mod'>text bleibt<ins class='diffins'>&nbsp;Test</ins></ins></strong></span>")]
+        [TestCase("<span>text remains</span>",
+              "<span><strong>text remains Test</strong></span>",
+              "<span><strong><ins class='mod'>text remains<ins class='diffins'>&nbsp;Test</ins></ins></strong></span>")]
 
         // Inserting a new word at the end of a reformatted text and another word at the end outside the reformatted text
-        [TestCase("<span>text bleibt</span>",
-             "<span><strong>text bleibt Test</strong> Test</span>",
-             "<span><strong><ins class='mod'>text bleibt<ins class='diffins'>&nbsp;Test</ins></ins></strong><ins class='diffins'>&nbsp;Test</ins></span>")]
+        [TestCase("<span>text remains</span>",
+             "<span><strong>text remains Test</strong> Test</span>",
+             "<span><strong><ins class='mod'>text remains<ins class='diffins'>&nbsp;Test</ins></ins></strong><ins class='diffins'>&nbsp;Test</ins></span>")]
 
         // Twice reformatted text with an offset at the end
-        [TestCase("<span>text bleibt</span>",
-             "<span><strong><big>text </big>bleibt</strong></span>",
-             "<span><strong><big><ins class='mod'>text </big>bleibt</ins></strong></span>")]
+        [TestCase("<span>text remains</span>",
+             "<span><strong><big>text </big>remains</strong></span>",
+             "<span><strong><big><ins class='mod'>text </big>remains</ins></strong></span>")]
 
         // Inserting a new word at the beginning of a reformatted text.
-        [TestCase("<span>text bleibt</span>",
-             "<span><strong>Test text bleibt</strong></span>",
-             "<span><strong><ins class='mod'><ins class='diffins'>Test </ins>text bleibt</ins></strong></span>")]
+        [TestCase("<span>text remains</span>",
+             "<span><strong>Test text remains</strong></span>",
+             "<span><strong><ins class='mod'><ins class='diffins'>Test </ins>text remains</ins></strong></span>")]
         public void TestCase_Issue20_missing_closing_tag(string oldText, string newText, string expectedResult)
         {
             // Arrange


### PR DESCRIPTION
I noticed an error when inserting an additional word at the end of a newly formatted text. A `</ins> `was inserted after the new word, but another closing tag for the opened `<ins class='mod'>` was missing. In my opinion, this corresponds to the problem described in Issue 20. I have added the problem described there as well as other edge cases that I consider relevant as additional test cases.